### PR TITLE
Fix checkmode

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -9,7 +9,7 @@
 - name: configure postfix
   command: "postconf -e {{ item.key }}={{ item.value }}"
   notify: "restart postfix"
-  when: "'{{ item.key }} = {{ item.value }}' not in postconf_result.stdout"
+  when: "'item.key = item.value' not in postconf_result.stdout"
   loop: "{{ aws_ses_settings | dict2items }}"
 
 - name: template SMTP credentials

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -4,6 +4,7 @@
   command: postconf
   register: postconf_result
   changed_when: false
+  check_mode: no
 
 - name: configure postfix
   command: "postconf -e {{ item.key }}={{ item.value }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -3,6 +3,7 @@
   command: "apt list --installed sendmail"
   register: sendmail_installed
   changed_when: false
+  check_mode: no
 
 - name: make sure sendmail is not installed
   fail:


### PR DESCRIPTION
- Improve handling of checkmode in role
- Fix templating delimiter warning. `[WARNING]: when statements should not include jinja2 templating delimiters such as {{ }} or {% %}. Found: '{{ item.key }} = {{ item.value }}' not in postconf_result.stdout`